### PR TITLE
Allow to mount /notebooks folder

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+cd $DIR && \
+
+docker rm -f ts
+docker run -p 8888:8888 -v $DIR/notebooks:/notebooks --name ts -it gcr.io/tensorflow/tensorflow


### PR DESCRIPTION
Allow to mount /notebooks folder to filesystem, and thus persist files between Jupyter runs locally. It means, no more keeping notebooks inside the container.